### PR TITLE
toJson的时候禁用转义

### DIFF
--- a/src/main/java/com/hp/dingtalk/pojo/message/worknotify/IDingWorkNotifyMsg.java
+++ b/src/main/java/com/hp/dingtalk/pojo/message/worknotify/IDingWorkNotifyMsg.java
@@ -18,6 +18,7 @@ import com.taobao.api.internal.util.StringUtils;
 public interface IDingWorkNotifyMsg extends IDingMsg {
     default String getMsg() {
         return new GsonBuilder()
+                .disableHtmlEscaping()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create()
                 .toJson(this);


### PR DESCRIPTION
解决toJson的时候会导致跳转链接中的符号会被encode转义